### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
 		"konva": "^3.3.3",
 		"lodash-es": "^4.17.11",
 		"markdown-to-jsx": "^6.9.4",
-		"npm": "^6.9.0",
 		"react": "^16.8.6",
 		"react-apollo": "^2.5.5",
 		"react-dom": "^16.8.6",


### PR DESCRIPTION

Hello AlvSovereign!

It seems like you have npm as one of your (dev-) dependency in Machiavellian-Maxims.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
